### PR TITLE
Fix list editor crash

### DIFF
--- a/MySaver/Views/ListEditorPage.xaml
+++ b/MySaver/Views/ListEditorPage.xaml
@@ -21,7 +21,8 @@
                 Source="checkmark.png"
                 HorizontalOptions="End"
                 Clicked="OnSaveTapped"
-                Style="{StaticResource Button}"/>
+                Background="{DynamicResource ButtonBackgroud}"
+                BorderColor="{DynamicResource ButtonBorderColor}"/>
 
         <SearchBar 
                 Placeholder="Produkto pavadinimas..." 


### PR DESCRIPTION
Fixed crashing when running without debug which was caused by incorrectly set style - ImageButton doesn't have TextColor property, which is set in Button style.