### PR TITLE
Made the product list initialization/reading lazy

### DIFF
--- a/MySaver/Views/ListEditorPage.xaml.cs
+++ b/MySaver/Views/ListEditorPage.xaml.cs
@@ -20,11 +20,6 @@ public partial class ListEditorPage : ContentPage
         startName = inputName;
     }
 
-    protected override async void OnAppearing()
-    {
-        SearchResults.ItemsSource = await viewModel.GetSearchResultsAsync(null);
-    }
-
     async void OnTextChanged(object sender, EventArgs e)
     {
         SearchBar search = (SearchBar)sender;


### PR DESCRIPTION
Semi-simple change in making the product list a Lazy type, which means that now when a shopping list is opened, the product data is only read when the user types into the search bar instead of upon page initialization.